### PR TITLE
Add RDS MySQL module with Secrets Manager and KMS encryption

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -31,3 +31,30 @@ module "eks" {
   endpoint_public_access_cidrs     = ["0.0.0.0/0"]
   control_plane_log_retention_days = 7
 }
+
+module "rds" {
+  source = "../../modules/rds"
+
+  environment        = var.environment
+  project_name       = "vibevault"
+  vpc_id             = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.private_subnet_ids
+
+  allowed_security_group_ids = [module.eks.cluster_security_group_id]
+
+  instance_class        = "db.t3.micro"
+  engine_version        = "8.4"
+  allocated_storage     = 20
+  max_allocated_storage = 100
+  storage_type          = "gp3"
+
+  db_name         = "vibevault"
+  master_username = "admin"
+  port            = 3306
+
+  multi_az                = false
+  backup_retention_period = 7
+  deletion_protection     = false
+  skip_final_snapshot     = true
+  log_retention_days      = 7
+}

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -34,3 +34,30 @@ output "eks_oidc_provider_arn" {
   description = "ARN of the OIDC provider for IRSA"
   value       = module.eks.oidc_provider_arn
 }
+
+# RDS Outputs
+
+output "rds_endpoint" {
+  description = "Connection endpoint of the RDS instance"
+  value       = module.rds.db_instance_endpoint
+}
+
+output "rds_address" {
+  description = "Hostname of the RDS instance"
+  value       = module.rds.db_instance_address
+}
+
+output "rds_port" {
+  description = "Port of the RDS instance"
+  value       = module.rds.db_instance_port
+}
+
+output "rds_db_name" {
+  description = "Name of the default database"
+  value       = module.rds.db_name
+}
+
+output "rds_master_user_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing the RDS master password"
+  value       = module.rds.master_user_secret_arn
+}

--- a/modules/rds/kms.tf
+++ b/modules/rds/kms.tf
@@ -1,0 +1,35 @@
+# ------------------------------------------------------------------------------
+# KMS Key for RDS Storage & Secrets Manager Encryption
+# ------------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "rds" {
+  description             = "KMS key for ${var.project_name}-${var.environment} RDS storage and secrets encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableRootAccountAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-rds-kms"
+  })
+}
+
+resource "aws_kms_alias" "rds" {
+  name          = "alias/${var.project_name}-${var.environment}-rds"
+  target_key_id = aws_kms_key.rds.key_id
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,0 +1,98 @@
+locals {
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+
+  identifier = "${var.project_name}-${var.environment}-mysql"
+}
+
+# ------------------------------------------------------------------------------
+# DB Subnet Group
+# ------------------------------------------------------------------------------
+
+resource "aws_db_subnet_group" "main" {
+  name        = "${var.project_name}-${var.environment}-db-subnet-group"
+  description = "DB subnet group for ${var.project_name}-${var.environment} RDS instance"
+  subnet_ids  = var.private_subnet_ids
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-db-subnet-group"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# CloudWatch Log Groups for RDS
+# ------------------------------------------------------------------------------
+
+# Pre-create log groups so we control retention. If RDS auto-creates them,
+# retention defaults to "Never expire" which wastes money.
+resource "aws_cloudwatch_log_group" "rds_error" {
+  name              = "/aws/rds/instance/${local.identifier}/error"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-rds-error-logs"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "rds_slowquery" {
+  name              = "/aws/rds/instance/${local.identifier}/slowquery"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-rds-slowquery-logs"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# RDS MySQL Instance
+# ------------------------------------------------------------------------------
+
+resource "aws_db_instance" "main" {
+  identifier = local.identifier
+  engine     = "mysql"
+
+  engine_version = var.engine_version
+  instance_class = var.instance_class
+
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage
+  storage_type          = var.storage_type
+  storage_encrypted     = true
+  kms_key_id            = aws_kms_key.rds.arn
+
+  db_name  = var.db_name
+  username = var.master_username
+  port     = var.port
+
+  # Secrets Manager manages the master password (never stored in Terraform state)
+  manage_master_user_password = true
+  master_user_secret_kms_key_id = aws_kms_key.rds.arn
+
+  multi_az               = var.multi_az
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+  parameter_group_name   = aws_db_parameter_group.mysql.name
+
+  backup_retention_period = var.backup_retention_period
+  backup_window           = "03:00-04:00"
+  maintenance_window      = "sun:04:30-sun:05:30"
+
+  enabled_cloudwatch_logs_exports = ["error", "slowquery"]
+
+  copy_tags_to_snapshot    = true
+  deletion_protection      = var.deletion_protection
+  skip_final_snapshot      = var.skip_final_snapshot
+  final_snapshot_identifier = var.skip_final_snapshot ? null : "${local.identifier}-final-snapshot"
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-rds-mysql"
+  })
+
+  depends_on = [
+    aws_cloudwatch_log_group.rds_error,
+    aws_cloudwatch_log_group.rds_slowquery,
+  ]
+}

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,44 @@
+output "db_instance_endpoint" {
+  description = "Connection endpoint of the RDS instance (includes port)"
+  value       = aws_db_instance.main.endpoint
+}
+
+output "db_instance_address" {
+  description = "Hostname of the RDS instance (without port)"
+  value       = aws_db_instance.main.address
+}
+
+output "db_instance_port" {
+  description = "Port of the RDS instance"
+  value       = aws_db_instance.main.port
+}
+
+output "db_instance_arn" {
+  description = "ARN of the RDS instance"
+  value       = aws_db_instance.main.arn
+}
+
+output "db_instance_identifier" {
+  description = "Identifier of the RDS instance"
+  value       = aws_db_instance.main.identifier
+}
+
+output "db_name" {
+  description = "Name of the default database"
+  value       = aws_db_instance.main.db_name
+}
+
+output "master_user_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing the master password"
+  value       = aws_db_instance.main.master_user_secret[0].secret_arn
+}
+
+output "security_group_id" {
+  description = "ID of the RDS security group"
+  value       = aws_security_group.rds.id
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used for RDS encryption"
+  value       = aws_kms_key.rds.arn
+}

--- a/modules/rds/parameters.tf
+++ b/modules/rds/parameters.tf
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------------------------
+# Custom Parameter Group for MySQL 8.4
+# ------------------------------------------------------------------------------
+
+resource "aws_db_parameter_group" "mysql" {
+  name        = "${var.project_name}-${var.environment}-mysql84"
+  family      = "mysql8.4"
+  description = "Custom parameter group for ${var.project_name}-${var.environment} MySQL 8.4"
+
+  parameter {
+    name  = "character_set_server"
+    value = "utf8mb4"
+  }
+
+  parameter {
+    name  = "collation_server"
+    value = "utf8mb4_unicode_ci"
+  }
+
+  parameter {
+    name  = "max_connections"
+    value = "100"
+  }
+
+  parameter {
+    name  = "slow_query_log"
+    value = "1"
+  }
+
+  parameter {
+    name  = "long_query_time"
+    value = "2"
+  }
+
+  parameter {
+    name  = "log_output"
+    value = "FILE"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-mysql84"
+  })
+}

--- a/modules/rds/security.tf
+++ b/modules/rds/security.tf
@@ -1,0 +1,24 @@
+# ------------------------------------------------------------------------------
+# Security Group for RDS MySQL Instance
+# ------------------------------------------------------------------------------
+
+resource "aws_security_group" "rds" {
+  name        = "${var.project_name}-${var.environment}-rds-sg"
+  description = "Security group for ${var.project_name}-${var.environment} RDS MySQL instance"
+  vpc_id      = var.vpc_id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-rds-sg"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds_mysql" {
+  count = length(var.allowed_security_group_ids)
+
+  security_group_id            = aws_security_group.rds.id
+  description                  = "Allow MySQL access from allowed security group"
+  from_port                    = var.port
+  to_port                      = var.port
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = var.allowed_security_group_ids[count.index]
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,118 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for resource tagging"
+  type        = string
+  default     = "vibevault"
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where the RDS instance will be deployed"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs for the DB subnet group"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.private_subnet_ids) >= 2
+    error_message = "At least 2 private subnet IDs must be provided for the DB subnet group."
+  }
+}
+
+variable "allowed_security_group_ids" {
+  description = "List of security group IDs allowed to access the RDS instance on the MySQL port"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.allowed_security_group_ids) >= 1
+    error_message = "At least 1 security group ID must be provided for RDS ingress."
+  }
+}
+
+variable "instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "engine_version" {
+  description = "MySQL engine version"
+  type        = string
+  default     = "8.4"
+}
+
+variable "allocated_storage" {
+  description = "Allocated storage in GB"
+  type        = number
+  default     = 20
+}
+
+variable "max_allocated_storage" {
+  description = "Maximum allocated storage in GB for autoscaling"
+  type        = number
+  default     = 100
+}
+
+variable "storage_type" {
+  description = "Storage type for the RDS instance"
+  type        = string
+  default     = "gp3"
+}
+
+variable "db_name" {
+  description = "Name of the default database to create"
+  type        = string
+  default     = "vibevault"
+}
+
+variable "master_username" {
+  description = "Master username for the RDS instance"
+  type        = string
+  default     = "admin"
+}
+
+variable "port" {
+  description = "Port for the RDS instance"
+  type        = number
+  default     = 3306
+}
+
+variable "multi_az" {
+  description = "Whether to deploy a Multi-AZ RDS instance"
+  type        = bool
+  default     = false
+}
+
+variable "backup_retention_period" {
+  description = "Number of days to retain automated backups"
+  type        = number
+  default     = 7
+}
+
+variable "deletion_protection" {
+  description = "Whether deletion protection is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "skip_final_snapshot" {
+  description = "Whether to skip the final snapshot when destroying the instance"
+  type        = bool
+  default     = true
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain RDS CloudWatch logs"
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.log_retention_days)
+    error_message = "log_retention_days must be a valid CloudWatch Logs retention value."
+  }
+}


### PR DESCRIPTION
## Summary
- Add reusable RDS MySQL module (`modules/rds/`) with db.t3.micro, MySQL 8.4, gp3 storage (20GB, autoscaling to 100GB)
- Master password managed by AWS Secrets Manager (`manage_master_user_password`) — never stored in Terraform state
- KMS encryption for both storage at rest and the Secrets Manager secret
- Custom parameter group with utf8mb4, slow query logging, and CloudWatch log exports (error + slowquery)
- Least-privilege security group: ingress only from EKS cluster SG on port 3306, no egress rules
- Wired into `environments/dev/` with outputs for endpoint, address, port, db name, and secret ARN

## Test plan
- [x] `terraform validate` passes
- [x] `terraform apply` succeeds — 9 new resources created, 0 changes to existing VPC/EKS
- [x] RDS instance available at `vibevault-dev-mysql.crwocs8oy0jv.ap-south-1.rds.amazonaws.com:3306`
- [x] Secrets Manager secret exists (`rds_master_user_secret_arn` output populated)
- [x] Storage encryption enabled with dedicated KMS key