### PR TITLE
Add ECR module for microservice container repositories

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -58,3 +58,9 @@ module "rds" {
   skip_final_snapshot     = true
   log_retention_days      = 7
 }
+
+module "ecr" {
+  source       = "../../modules/ecr"
+  environment  = var.environment
+  project_name = "vibevault"
+}

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -61,3 +61,10 @@ output "rds_master_user_secret_arn" {
   description = "ARN of the Secrets Manager secret containing the RDS master password"
   value       = module.rds.master_user_secret_arn
 }
+
+# ECR Outputs
+
+output "ecr_repository_urls" {
+  description = "Map of service name to ECR repository URL"
+  value       = module.ecr.repository_urls
+}

--- a/modules/ecr/kms.tf
+++ b/modules/ecr/kms.tf
@@ -1,0 +1,35 @@
+# ------------------------------------------------------------------------------
+# KMS Key for ECR Image Encryption
+# ------------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "ecr" {
+  description             = "KMS key for ${var.project_name}-${var.environment} ECR image encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableRootAccountAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-ecr-kms"
+  })
+}
+
+resource "aws_kms_alias" "ecr" {
+  name          = "alias/${var.project_name}-${var.environment}-ecr"
+  target_key_id = aws_kms_key.ecr.key_id
+}

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,70 @@
+locals {
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+# ------------------------------------------------------------------------------
+# ECR Repositories
+# ------------------------------------------------------------------------------
+
+resource "aws_ecr_repository" "this" {
+  for_each = toset(var.repository_names)
+
+  name                 = "${var.project_name}-${var.environment}/${each.value}"
+  image_tag_mutability = var.image_tag_mutability
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.ecr.arn
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-${each.value}"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# Lifecycle Policies
+# ------------------------------------------------------------------------------
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each = toset(var.repository_names)
+
+  repository = aws_ecr_repository.this[each.key].name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 10
+        description  = "Expire untagged images after ${var.untagged_image_expiry_days} days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = var.untagged_image_expiry_days
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 20
+        description  = "Keep only the last ${var.max_image_count} images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.max_image_count
+        }
+        action = {
+          type = "expire"
+        }
+      },
+    ]
+  })
+}

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,18 @@
+output "repository_urls" {
+  description = "Map of repository name to ECR repository URL"
+  value = {
+    for name, repo in aws_ecr_repository.this : name => repo.repository_url
+  }
+}
+
+output "repository_arns" {
+  description = "Map of repository name to ECR repository ARN"
+  value = {
+    for name, repo in aws_ecr_repository.this : name => repo.arn
+  }
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used for ECR encryption"
+  value       = aws_kms_key.ecr.arn
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,52 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for resource tagging"
+  type        = string
+  default     = "vibevault"
+}
+
+variable "repository_names" {
+  description = "List of ECR repository names to create"
+  type        = list(string)
+  default = [
+    "user-service",
+    "product-service",
+    "cart-service",
+    "order-service",
+    "payment-service",
+    "notification-service",
+  ]
+}
+
+variable "image_tag_mutability" {
+  description = "Tag mutability setting for repositories (MUTABLE or IMMUTABLE)"
+  type        = string
+  default     = "IMMUTABLE"
+
+  validation {
+    condition     = contains(["MUTABLE", "IMMUTABLE"], var.image_tag_mutability)
+    error_message = "image_tag_mutability must be either \"MUTABLE\" or \"IMMUTABLE\"."
+  }
+}
+
+variable "scan_on_push" {
+  description = "Whether to enable image scanning on push"
+  type        = bool
+  default     = true
+}
+
+variable "max_image_count" {
+  description = "Maximum number of tagged images to retain per repository"
+  type        = number
+  default     = 10
+}
+
+variable "untagged_image_expiry_days" {
+  description = "Number of days after which untagged images are expired"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
## Summary
- Add ECR module with KMS-encrypted repositories for all 6 microservices (user, product, cart, order, payment, notification)
- Immutable tags and scan-on-push enabled for supply-chain security
- Lifecycle policies to expire untagged images after 1 day and cap total images at 10 per repo
- Wire ECR module into dev environment and expose repository URLs output

## Test plan
- [x] `terraform init -upgrade` succeeds
- [x] `terraform validate` passes
- [x] `terraform apply` creates 14 resources (KMS key + alias, 6 repos, 6 lifecycle policies)
- [x] `terraform output ecr_repository_urls` returns all 6 repo URLs
- [x] Verify in AWS Console: KMS encryption enabled, lifecycle policies attached, scan-on-push enabled