### PR TITLE
Add RSA keys to Secrets Manager, fix DB grants, and mutable ECR tags

### DIFF
--- a/k8s/db-init-job.yaml
+++ b/k8s/db-init-job.yaml
@@ -25,7 +25,7 @@ spec:
             - -c
             - |
               export MYSQL_PWD="$MASTER_PASSWORD"
-              printf 'CREATE DATABASE IF NOT EXISTS userservice;\nCREATE DATABASE IF NOT EXISTS productservice;\nCREATE USER IF NOT EXISTS '\''userservice_user'\''@'\''%%'\'' IDENTIFIED BY '\''%s'\'';\nGRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, INDEX, DROP ON userservice.* TO '\''userservice_user'\''@'\''%%'\'';\nCREATE USER IF NOT EXISTS '\''productservice_user'\''@'\''%%'\'' IDENTIFIED BY '\''%s'\'';\nGRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, INDEX, DROP ON productservice.* TO '\''productservice_user'\''@'\''%%'\'';\nFLUSH PRIVILEGES;\n' \
+              printf 'CREATE DATABASE IF NOT EXISTS userservice;\nCREATE DATABASE IF NOT EXISTS productservice;\nCREATE USER IF NOT EXISTS '\''userservice_user'\''@'\''%%'\'' IDENTIFIED BY '\''%s'\'';\nGRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, INDEX, DROP, REFERENCES ON userservice.* TO '\''userservice_user'\''@'\''%%'\'';\nCREATE USER IF NOT EXISTS '\''productservice_user'\''@'\''%%'\'' IDENTIFIED BY '\''%s'\'';\nGRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ALTER, INDEX, DROP, REFERENCES ON productservice.* TO '\''productservice_user'\''@'\''%%'\'';\nFLUSH PRIVILEGES;\n' \
                 "$USERSERVICE_DB_PASSWORD" \
                 "$PRODUCTSERVICE_DB_PASSWORD" \
               | mysql -h "$RDS_HOST" -P "$RDS_PORT" -u "$MASTER_USERNAME"

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -25,7 +25,7 @@ variable "repository_names" {
 variable "image_tag_mutability" {
   description = "Tag mutability setting for repositories (MUTABLE or IMMUTABLE)"
   type        = string
-  default     = "IMMUTABLE"
+  default     = "MUTABLE"
 
   validation {
     condition     = contains(["MUTABLE", "IMMUTABLE"], var.image_tag_mutability)

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -48,9 +48,10 @@ resource "tls_private_key" "jwt_signing" {
 # ------------------------------------------------------------------------------
 
 resource "aws_secretsmanager_secret" "userservice_db" {
-  name        = "${local.prefix}/userservice/db-credentials"
-  description = "Database credentials for userservice"
-  kms_key_id  = var.kms_key_arn
+  name                    = "${local.prefix}/userservice/db-credentials"
+  description             = "Database credentials for userservice"
+  kms_key_id              = var.kms_key_arn
+  recovery_window_in_days = 0
 
   tags = merge(local.common_tags, {
     Service = "userservice"
@@ -70,9 +71,10 @@ resource "aws_secretsmanager_secret_version" "userservice_db" {
 # ------------------------------------------------------------------------------
 
 resource "aws_secretsmanager_secret" "productservice_db" {
-  name        = "${local.prefix}/productservice/db-credentials"
-  description = "Database credentials for productservice"
-  kms_key_id  = var.kms_key_arn
+  name                    = "${local.prefix}/productservice/db-credentials"
+  description             = "Database credentials for productservice"
+  kms_key_id              = var.kms_key_arn
+  recovery_window_in_days = 0
 
   tags = merge(local.common_tags, {
     Service = "productservice"
@@ -92,9 +94,10 @@ resource "aws_secretsmanager_secret_version" "productservice_db" {
 # ------------------------------------------------------------------------------
 
 resource "aws_secretsmanager_secret" "userservice_app" {
-  name        = "${local.prefix}/userservice/app-secrets"
-  description = "Application secrets for userservice (admin password, OAuth client secret)"
-  kms_key_id  = var.kms_key_arn
+  name                    = "${local.prefix}/userservice/app-secrets"
+  description             = "Application secrets for userservice (admin password, OAuth client secret)"
+  kms_key_id              = var.kms_key_arn
+  recovery_window_in_days = 0
 
   tags = merge(local.common_tags, {
     Service = "userservice"

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -48,10 +48,9 @@ resource "tls_private_key" "jwt_signing" {
 # ------------------------------------------------------------------------------
 
 resource "aws_secretsmanager_secret" "userservice_db" {
-  name                    = "${local.prefix}/userservice/db-credentials"
-  description             = "Database credentials for userservice"
-  kms_key_id              = var.kms_key_arn
-  recovery_window_in_days = 0
+  name        = "${local.prefix}/userservice/db-credentials"
+  description = "Database credentials for userservice"
+  kms_key_id  = var.kms_key_arn
 
   tags = merge(local.common_tags, {
     Service = "userservice"
@@ -71,10 +70,9 @@ resource "aws_secretsmanager_secret_version" "userservice_db" {
 # ------------------------------------------------------------------------------
 
 resource "aws_secretsmanager_secret" "productservice_db" {
-  name                    = "${local.prefix}/productservice/db-credentials"
-  description             = "Database credentials for productservice"
-  kms_key_id              = var.kms_key_arn
-  recovery_window_in_days = 0
+  name        = "${local.prefix}/productservice/db-credentials"
+  description = "Database credentials for productservice"
+  kms_key_id  = var.kms_key_arn
 
   tags = merge(local.common_tags, {
     Service = "productservice"
@@ -94,10 +92,9 @@ resource "aws_secretsmanager_secret_version" "productservice_db" {
 # ------------------------------------------------------------------------------
 
 resource "aws_secretsmanager_secret" "userservice_app" {
-  name                    = "${local.prefix}/userservice/app-secrets"
-  description             = "Application secrets for userservice (admin password, OAuth client secret)"
-  kms_key_id              = var.kms_key_arn
-  recovery_window_in_days = 0
+  name        = "${local.prefix}/userservice/app-secrets"
+  description = "Application secrets for userservice (admin password, OAuth client secret)"
+  kms_key_id  = var.kms_key_arn
 
   tags = merge(local.common_tags, {
     Service = "userservice"

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -35,6 +35,15 @@ resource "random_password" "userservice_client_secret" {
 }
 
 # ------------------------------------------------------------------------------
+# RSA Key Pair for JWT Signing (persisted across pod restarts)
+# ------------------------------------------------------------------------------
+
+resource "tls_private_key" "jwt_signing" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+# ------------------------------------------------------------------------------
 # Userservice DB Credentials
 # ------------------------------------------------------------------------------
 
@@ -98,8 +107,10 @@ resource "aws_secretsmanager_secret" "userservice_app" {
 resource "aws_secretsmanager_secret_version" "userservice_app" {
   secret_id = aws_secretsmanager_secret.userservice_app.id
   secret_string = jsonencode({
-    ADMIN_PASSWORD = random_password.userservice_admin.result
-    CLIENT_SECRET  = random_password.userservice_client_secret.result
+    ADMIN_PASSWORD  = random_password.userservice_admin.result
+    CLIENT_SECRET   = random_password.userservice_client_secret.result
+    RSA_PRIVATE_KEY = tls_private_key.jwt_signing.private_key_pem
+    RSA_PUBLIC_KEY  = tls_private_key.jwt_signing.public_key_pem
   })
 }
 


### PR DESCRIPTION
## Summary
- Generate RSA key pair via `tls_private_key` and store in Secrets Manager for JWT signing (closes #8)
- Add `REFERENCES` privilege to db-init job grants, required for Flyway to create foreign key constraints
- Switch ECR `image_tag_mutability` default from `IMMUTABLE` to `MUTABLE` for iterative development

## Test plan
- [x] Verified RSA keys stored correctly in Secrets Manager and loaded by userservice
- [x] Confirmed Flyway V1 migration (with foreign keys) completes successfully with `REFERENCES` grant
- [x] Verified Docker push with mutable `latest` tag works