### PR TITLE
Add GitHub Actions CI/CD pipeline for infrastructure

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -1,0 +1,109 @@
+name: Infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Action to perform"
+        required: true
+        type: choice
+        options:
+          - plan
+          - apply
+          - destroy
+      environment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - dev
+        default: dev
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-south-1
+  TF_VERSION: "1.14.6"
+
+jobs:
+  terraform:
+    name: "Terraform ${{ inputs.action }} (${{ inputs.environment }})"
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    defaults:
+      run:
+        working-directory: environments/${{ inputs.environment }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      # ---------- PLAN ----------
+      - name: "Plan: Stage 1 — VPC + ECR"
+        if: inputs.action == 'plan'
+        run: terraform plan -target=module.vpc -target=module.ecr
+
+      - name: "Plan: Stage 2 — EKS"
+        if: inputs.action == 'plan'
+        run: terraform plan -target=module.eks
+
+      - name: "Plan: Stage 3 — RDS + Secrets"
+        if: inputs.action == 'plan'
+        run: terraform plan -target=module.rds -target=module.secrets
+
+      - name: "Plan: Stage 4 — Full (remaining refs)"
+        if: inputs.action == 'plan'
+        run: terraform plan
+
+      # ---------- APPLY (staged to break circular deps) ----------
+      # VPC + ECR have no dependencies
+      - name: "Apply: Stage 1 — VPC + ECR"
+        if: inputs.action == 'apply'
+        run: terraform apply -auto-approve -target=module.vpc -target=module.ecr
+
+      # EKS needs VPC outputs; creates cluster_security_group_id needed by RDS
+      - name: "Apply: Stage 2 — EKS"
+        if: inputs.action == 'apply'
+        run: terraform apply -auto-approve -target=module.eks
+
+      # RDS needs EKS security group; Secrets needs RDS KMS key
+      - name: "Apply: Stage 3 — RDS + Secrets"
+        if: inputs.action == 'apply'
+        run: terraform apply -auto-approve -target=module.rds -target=module.secrets
+
+      # Final pass wires cross-module refs (EKS IRSA ↔ RDS/Secrets ARNs)
+      - name: "Apply: Stage 4 — Full (wire cross-module refs)"
+        if: inputs.action == 'apply'
+        run: terraform apply -auto-approve
+
+      # ---------- DESTROY (reverse order) ----------
+      - name: "Destroy: Stage 1 — EKS"
+        if: inputs.action == 'destroy'
+        run: terraform destroy -auto-approve -target=module.eks
+
+      - name: "Destroy: Stage 2 — RDS + Secrets"
+        if: inputs.action == 'destroy'
+        run: terraform destroy -auto-approve -target=module.rds -target=module.secrets
+
+      - name: "Destroy: Stage 3 — VPC + ECR"
+        if: inputs.action == 'destroy'
+        run: terraform destroy -auto-approve -target=module.vpc -target=module.ecr

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -82,3 +82,79 @@ resource "aws_dynamodb_table" "terraform_locks" {
     Purpose = "Terraform state locking"
   }
 }
+
+# ------------------------------------------------------------------------------
+# GitHub OIDC Provider — lets GitHub Actions assume IAM roles without secrets
+# ------------------------------------------------------------------------------
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["ffffffffffffffffffffffffffffffffffffffff"]
+
+  tags = {
+    Name    = "github-oidc"
+    Project = "vibevault"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# IAM Role assumed by GitHub Actions via OIDC
+# ------------------------------------------------------------------------------
+
+variable "github_repos" {
+  description = "GitHub repos allowed to assume the CI/CD role"
+  type        = list(string)
+  default = [
+    "spa-raj/vibevault-infra",
+    "spa-raj/userservice",
+    "spa-raj/productservice",
+  ]
+}
+
+data "aws_iam_policy_document" "github_actions_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = [for repo in var.github_repos : "repo:${repo}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  name               = "vibevault-github-actions"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_trust.json
+
+  tags = {
+    Name    = "vibevault-github-actions"
+    Project = "vibevault"
+    Purpose = "GitHub Actions CI/CD"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_admin" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+output "github_actions_role_arn" {
+  description = "ARN to set as AWS_ROLE_ARN secret in all GitHub repos"
+  value       = aws_iam_role.github_actions.arn
+}


### PR DESCRIPTION
## Summary
- Add manual `workflow_dispatch` workflow with `plan`, `apply`, and `destroy` actions
- Staged Terraform execution to handle circular module dependencies (VPC → EKS → RDS → full wiring)
- Destroy runs in reverse order (EKS → RDS+Secrets → VPC+ECR)
- Add GitHub OIDC provider and IAM role in bootstrap module for keyless AWS authentication
- IAM role trusts all 3 repos (vibevault-infra, userservice, productservice)

Closes #10

## Test plan
- [ ] Run `plan` action from GitHub Actions and verify all stages complete
- [ ] Run `apply` action and verify infrastructure is provisioned
- [ ] Run `destroy` action and verify teardown completes cleanly
- [ ] Verify OIDC authentication works (no stored AWS credentials)