### PR TITLE
Add post-apply K8s setup, EKS CI/CD access, sensitive outputs

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -26,6 +26,7 @@ permissions:
 env:
   AWS_REGION: ap-south-1
   TF_VERSION: "1.14.6"
+  EKS_CLUSTER_NAME: vibevault-${{ inputs.environment }}
 
 jobs:
   terraform:
@@ -107,3 +108,63 @@ jobs:
       - name: "Destroy: Stage 3 — VPC + ECR"
         if: inputs.action == 'destroy'
         run: terraform destroy -auto-approve -target=module.vpc -target=module.ecr
+
+  # ---------- POST-APPLY: Configure K8s resources ----------
+  post-apply:
+    name: "Configure Kubernetes"
+    needs: terraform
+    if: inputs.action == 'apply'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Configure kubectl
+        run: aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
+
+      - name: Create vibevault namespace
+        run: kubectl create namespace vibevault --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Resolve REPLACE_ placeholders and apply K8s manifests
+        run: |
+          # Query RDS for dynamic values
+          RDS_ADDRESS=$(aws rds describe-db-instances \
+            --db-instance-identifier ${{ env.EKS_CLUSTER_NAME }}-mysql \
+            --query 'DBInstances[0].Endpoint.Address' --output text)
+
+          RDS_MASTER_SECRET_ARN=$(aws rds describe-db-instances \
+            --db-instance-identifier ${{ env.EKS_CLUSTER_NAME }}-mysql \
+            --query 'DBInstances[0].MasterUserSecret.SecretArn' --output text)
+
+          echo "RDS Address: $RDS_ADDRESS"
+          echo "RDS Master Secret ARN: $RDS_MASTER_SECRET_ARN"
+
+          # Apply ClusterSecretStore
+          kubectl apply -f k8s/cluster-secret-store.yaml
+
+          # Apply db-init ExternalSecrets with placeholders resolved
+          sed \
+            -e "s|REPLACE_WITH_RDS_ADDRESS|${RDS_ADDRESS}|g" \
+            -e "s|REPLACE_WITH_RDS_MASTER_SECRET_ARN|${RDS_MASTER_SECRET_ARN}|g" \
+            k8s/db-init-external-secrets.yaml | kubectl apply -f -
+
+          # Wait for ExternalSecrets to sync
+          echo "Waiting for ExternalSecrets to sync..."
+          kubectl wait externalsecret/db-init-master-secret -n vibevault --for=condition=SecretSynced --timeout=60s
+          kubectl wait externalsecret/db-init-service-secrets -n vibevault --for=condition=SecretSynced --timeout=60s
+
+          # Run the DB init job (delete previous run if exists)
+          kubectl delete job db-init -n vibevault --ignore-not-found
+          kubectl apply -f k8s/db-init-job.yaml
+
+          # Wait for job completion
+          kubectl wait job/db-init -n vibevault --for=condition=complete --timeout=120s
+          echo "DB init job completed successfully"

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -2,6 +2,8 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
+data "aws_caller_identity" "current" {}
+
 module "vpc" {
   source = "../../modules/vpc"
 
@@ -30,6 +32,7 @@ module "eks" {
 
   endpoint_public_access_cidrs     = ["0.0.0.0/0"]
   control_plane_log_retention_days = 7
+  ci_cd_role_arn                   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/vibevault-github-actions"
 
   secret_arns          = concat(module.secrets.all_secret_arns, [module.rds.master_user_secret_arn])
   secrets_kms_key_arns = [module.rds.kms_key_arn]

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -1,21 +1,25 @@
 output "vpc_id" {
   description = "ID of the VPC"
   value       = module.vpc.vpc_id
+  sensitive   = true
 }
 
 output "public_subnet_ids" {
   description = "IDs of the public subnets"
   value       = module.vpc.public_subnet_ids
+  sensitive   = true
 }
 
 output "private_subnet_ids" {
   description = "IDs of the private subnets"
   value       = module.vpc.private_subnet_ids
+  sensitive   = true
 }
 
 output "nat_gateway_id" {
   description = "ID of the NAT Gateway"
   value       = module.vpc.nat_gateway_id
+  sensitive   = true
 }
 
 # EKS Outputs
@@ -23,16 +27,19 @@ output "nat_gateway_id" {
 output "eks_cluster_name" {
   description = "Name of the EKS cluster"
   value       = module.eks.cluster_name
+  sensitive   = true
 }
 
 output "eks_cluster_endpoint" {
   description = "Endpoint URL of the EKS cluster API server"
   value       = module.eks.cluster_endpoint
+  sensitive   = true
 }
 
 output "eks_oidc_provider_arn" {
   description = "ARN of the OIDC provider for IRSA"
   value       = module.eks.oidc_provider_arn
+  sensitive   = true
 }
 
 # RDS Outputs
@@ -40,26 +47,31 @@ output "eks_oidc_provider_arn" {
 output "rds_endpoint" {
   description = "Connection endpoint of the RDS instance"
   value       = module.rds.db_instance_endpoint
+  sensitive   = true
 }
 
 output "rds_address" {
   description = "Hostname of the RDS instance"
   value       = module.rds.db_instance_address
+  sensitive   = true
 }
 
 output "rds_port" {
   description = "Port of the RDS instance"
   value       = module.rds.db_instance_port
+  sensitive   = true
 }
 
 output "rds_db_name" {
   description = "Name of the default database"
   value       = module.rds.db_name
+  sensitive   = true
 }
 
 output "rds_master_user_secret_arn" {
   description = "ARN of the Secrets Manager secret containing the RDS master password"
   value       = module.rds.master_user_secret_arn
+  sensitive   = true
 }
 
 # Secrets Manager Outputs
@@ -67,21 +79,25 @@ output "rds_master_user_secret_arn" {
 output "secrets_userservice_db_arn" {
   description = "ARN of the userservice DB credentials secret"
   value       = module.secrets.userservice_db_secret_arn
+  sensitive   = true
 }
 
 output "secrets_productservice_db_arn" {
   description = "ARN of the productservice DB credentials secret"
   value       = module.secrets.productservice_db_secret_arn
+  sensitive   = true
 }
 
 output "secrets_userservice_app_arn" {
   description = "ARN of the userservice app secrets"
   value       = module.secrets.userservice_app_secret_arn
+  sensitive   = true
 }
 
 output "external_secrets_role_arn" {
   description = "ARN of the IRSA role for External Secrets Operator"
   value       = module.eks.external_secrets_role_arn
+  sensitive   = true
 }
 
 # ECR Outputs
@@ -89,4 +105,5 @@ output "external_secrets_role_arn" {
 output "ecr_repository_urls" {
   description = "Map of service name to ECR repository URL"
   value       = module.ecr.repository_urls
+  sensitive   = true
 }

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -119,6 +119,36 @@ resource "aws_eks_node_group" "main" {
 # OIDC Provider for IRSA (IAM Roles for Service Accounts)
 # ------------------------------------------------------------------------------
 
+# ------------------------------------------------------------------------------
+# EKS Access Entry for GitHub Actions CI/CD Role
+# ------------------------------------------------------------------------------
+
+resource "aws_eks_access_entry" "ci_cd" {
+  count         = var.ci_cd_role_arn != "" ? 1 : 0
+  cluster_name  = aws_eks_cluster.main.name
+  principal_arn = var.ci_cd_role_arn
+  type          = "STANDARD"
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-cicd-access"
+  })
+}
+
+resource "aws_eks_access_policy_association" "ci_cd_admin" {
+  count         = var.ci_cd_role_arn != "" ? 1 : 0
+  cluster_name  = aws_eks_cluster.main.name
+  principal_arn = var.ci_cd_role_arn
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+}
+
+# ------------------------------------------------------------------------------
+# OIDC Provider for IRSA (IAM Roles for Service Accounts)
+# ------------------------------------------------------------------------------
+
 data "tls_certificate" "eks" {
   url = aws_eks_cluster.main.identity[0].oidc[0].issuer
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -98,6 +98,12 @@ variable "secrets_kms_key_arns" {
   default     = []
 }
 
+variable "ci_cd_role_arn" {
+  description = "IAM role ARN for GitHub Actions CI/CD to access the EKS cluster"
+  type        = string
+  default     = ""
+}
+
 variable "control_plane_log_retention_days" {
   description = "Number of days to retain EKS control plane logs in CloudWatch"
   type        = number


### PR DESCRIPTION
## Summary
- Add EKS access entry + cluster admin policy for the GitHub Actions IAM role so `kubectl` works from the pipeline
- Add `post-apply` job that runs after successful `apply`:
  - Configures kubectl via `aws eks update-kubeconfig`
  - Creates `vibevault` namespace
  - Queries RDS for address and master secret ARN via AWS API
  - Resolves `REPLACE_` placeholders in `k8s/db-init-external-secrets.yaml` via `sed`
  - Applies ClusterSecretStore, ExternalSecrets, and db-init job
  - Waits for ExternalSecrets sync and job completion
- Mark all Terraform outputs as `sensitive` to redact infrastructure details from public CI logs

Closes #12

## Test plan
- [ ] Run `plan` action and verify EKS access entry appears in the plan
- [ ] Run `apply` action and verify post-apply job completes (namespace, secrets, db-init)
- [ ] Verify Terraform outputs are redacted in CI logs
- [ ] Verify `kubectl` access works from the pipeline via the OIDC role