### PR TITLE
Enable API_AND_CONFIG_MAP auth mode on EKS for access entries

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -62,6 +62,10 @@ resource "aws_eks_cluster" "main" {
     security_group_ids      = [aws_security_group.cluster_additional.id]
   }
 
+  access_config {
+    authentication_mode = "API_AND_CONFIG_MAP"
+  }
+
   enabled_cluster_log_types = local.cluster_log_types
 
   encryption_config {


### PR DESCRIPTION
## Summary
- Add `access_config { authentication_mode = "API_AND_CONFIG_MAP" }` to the EKS cluster resource
- Required for `aws_eks_access_entry` and `aws_eks_access_policy_association` to work (CI/CD role access added in #13)
- Without this, EKS defaults to `CONFIG_MAP` mode which rejects access entry API calls

## Test plan
- [ ] Run `apply` from GitHub Actions and verify Stage 2 (EKS) succeeds
- [ ] Verify post-apply job can run `kubectl` commands against the cluster