### PR TITLE
Fix EKS access config to prevent cluster replacement

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -63,7 +63,8 @@ resource "aws_eks_cluster" "main" {
   }
 
   access_config {
-    authentication_mode = "API_AND_CONFIG_MAP"
+    authentication_mode                         = "API_AND_CONFIG_MAP"
+    bootstrap_cluster_creator_admin_permissions = true
   }
 
   enabled_cluster_log_types = local.cluster_log_types


### PR DESCRIPTION
## Summary
- Add `bootstrap_cluster_creator_admin_permissions = true` to `access_config` block to prevent Terraform from destroying and recreating the EKS cluster
- Without this, changing `authentication_mode` to `API_AND_CONFIG_MAP` triggered a force replacement due to the `null` default

## Context
PR #14 introduced `access_config` with only `authentication_mode` set. Terraform interpreted the missing `bootstrap_cluster_creator_admin_permissions` as `null`, which forced cluster replacement. The failed apply also destroyed the OIDC provider, which has been recovered via `terraform apply` locally.

Closes #12

## Test plan
- [x] `terraform plan` shows in-place update (no destroy/replace)
- [x] `terraform apply` completed successfully — access entry and policy created
- [ ] Run `apply` from GitHub Actions and verify post-apply job succeeds