### PR TITLE
Add ESO Helm install to post-apply job

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -133,6 +133,20 @@ jobs:
       - name: Create vibevault namespace
         run: kubectl create namespace vibevault --dry-run=client -o yaml | kubectl apply -f -
 
+      - name: Install External Secrets Operator
+        run: |
+          # Get AWS account ID for IRSA role ARN
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          ESO_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${{ env.EKS_CLUSTER_NAME }}-external-secrets-role"
+
+          helm repo add external-secrets https://charts.external-secrets.io
+          helm repo update
+
+          helm upgrade --install external-secrets external-secrets/external-secrets \
+            -n external-secrets --create-namespace \
+            --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="${ESO_ROLE_ARN}" \
+            --wait --timeout 120s
+
       - name: Resolve REPLACE_ placeholders and apply K8s manifests
         run: |
           # Query RDS for dynamic values


### PR DESCRIPTION
## Summary
- Add External Secrets Operator Helm install/upgrade step before applying K8s manifests
- Uses `helm upgrade --install` with `--wait` for idempotent installs and credential refresh
- Derives IRSA role ARN dynamically from AWS account ID and cluster name

## Context
The post-apply job applies ExternalSecret resources that depend on ESO being installed. Previously ESO was installed manually. This step ensures it's always present and running with fresh IRSA credentials after infrastructure changes.

## Test plan
- [ ] Run `apply` and verify ESO is installed/upgraded in post-apply
- [ ] Verify ExternalSecrets sync successfully after ESO install
- [ ] Verify db-init job completes

Closes #12 