### PR TITLE
Fix ExternalSecret wait condition in post-apply job

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -172,8 +172,8 @@ jobs:
 
           # Wait for ExternalSecrets to sync
           echo "Waiting for ExternalSecrets to sync..."
-          kubectl wait externalsecret/db-init-master-secret -n vibevault --for=condition=SecretSynced --timeout=60s
-          kubectl wait externalsecret/db-init-service-secrets -n vibevault --for=condition=SecretSynced --timeout=60s
+          kubectl wait externalsecret/db-init-master-secret -n vibevault --for=condition=Ready --timeout=60s
+          kubectl wait externalsecret/db-init-service-secrets -n vibevault --for=condition=Ready --timeout=60s
 
           # Run the DB init job (delete previous run if exists)
           kubectl delete job db-init -n vibevault --ignore-not-found


### PR DESCRIPTION
## Summary
- Fix `kubectl wait` condition from `SecretSynced` to `Ready`
- The ExternalSecret CRD uses `Ready` as the condition type, not `SecretSynced` (which is the reason/message, not the condition name)

## Test plan
- [ ] Run `apply` and verify post-apply job passes the ExternalSecret wait step
- [ ] Verify db-init job runs and completes successfully