### PR TITLE
Remove $, {, } from DB password special characters

### DIFF
--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -15,13 +15,13 @@ locals {
 resource "random_password" "userservice_db" {
   length           = 32
   special          = true
-  override_special = "!#$%&*()-_=+[]{}:?"
+  override_special = "!#%&*()-_=+:?"
 }
 
 resource "random_password" "productservice_db" {
   length           = 32
   special          = true
-  override_special = "!#$%&*()-_=+[]{}:?"
+  override_special = "!#%&*()-_=+:?"
 }
 
 resource "random_password" "userservice_admin" {


### PR DESCRIPTION
## Summary
- Remove `$`, `{`, `}` from `override_special` in `random_password` resources for service DB credentials
- These characters can form `${...}` patterns that Spring Boot's property resolver interprets as nested placeholders, mangling passwords and causing `Access denied` errors

Closes #18

## Test plan
- [ ] Run `terraform plan` to verify password regeneration
- [ ] Run `terraform apply` to rotate passwords in Secrets Manager
- [ ] Redeploy userservice and productservice — db-init hooks will set new passwords in MySQL
- [ ] Verify both services reach Running state without `Access denied` errors