### PR TITLE
Add AWS OpenSearch Terraform module for Elasticsearch deployment

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -73,6 +73,26 @@ module "secrets" {
   kms_key_arn  = module.rds.kms_key_arn
 }
 
+module "opensearch" {
+  source = "../../modules/opensearch"
+
+  environment        = var.environment
+  project_name       = "vibevault"
+  vpc_id             = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.private_subnet_ids
+
+  allowed_security_group_ids = [module.eks.cluster_security_group_id]
+
+  engine_version = "OpenSearch_2.17"
+  instance_type  = "t3.small.search"
+  instance_count = 1
+  ebs_volume_size = 10
+  ebs_volume_type = "gp3"
+
+  multi_az           = false
+  log_retention_days = 7
+}
+
 module "ecr" {
   source       = "../../modules/ecr"
   environment  = var.environment

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -114,6 +114,12 @@ output "opensearch_domain_name" {
   sensitive   = true
 }
 
+output "opensearch_domain_arn" {
+  description = "ARN of the OpenSearch domain"
+  value       = module.opensearch.domain_arn
+  sensitive   = true
+}
+
 # ECR Outputs
 
 output "ecr_repository_urls" {

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -100,6 +100,20 @@ output "external_secrets_role_arn" {
   sensitive   = true
 }
 
+# OpenSearch Outputs
+
+output "opensearch_endpoint" {
+  description = "HTTPS endpoint of the OpenSearch domain"
+  value       = module.opensearch.domain_endpoint
+  sensitive   = true
+}
+
+output "opensearch_domain_name" {
+  description = "Name of the OpenSearch domain"
+  value       = module.opensearch.domain_name
+  sensitive   = true
+}
+
 # ECR Outputs
 
 output "ecr_repository_urls" {

--- a/modules/opensearch/main.tf
+++ b/modules/opensearch/main.tf
@@ -36,10 +36,14 @@ resource "aws_cloudwatch_log_resource_policy" "opensearch" {
         }
         Action = [
           "logs:PutLogEvents",
-          "logs:PutLogEventsBatch",
           "logs:CreateLogStream",
         ]
         Resource = "${aws_cloudwatch_log_group.opensearch.arn}:*"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
       }
     ]
   })
@@ -52,6 +56,17 @@ resource "aws_cloudwatch_log_resource_policy" "opensearch" {
 resource "aws_opensearch_domain" "main" {
   domain_name    = local.domain_name
   engine_version = var.engine_version
+
+  lifecycle {
+    precondition {
+      condition     = !var.multi_az || length(var.private_subnet_ids) >= 2
+      error_message = "At least 2 private subnet IDs are required when multi_az is enabled."
+    }
+    precondition {
+      condition     = !var.multi_az || (var.instance_count >= 2 && var.instance_count % 2 == 0)
+      error_message = "instance_count must be at least 2 and even when multi_az is enabled."
+    }
+  }
 
   cluster_config {
     instance_type          = var.instance_type
@@ -90,14 +105,14 @@ resource "aws_opensearch_domain" "main" {
     tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
   }
 
-  # Open access policy — access is controlled via VPC security group
+  # Restrict to HTTP actions only — network access is controlled via VPC security group
   access_policies = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
         Effect    = "Allow"
         Principal = "*"
-        Action    = "es:*"
+        Action    = "es:ESHttp*"
         Resource  = "arn:aws:es:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:domain/${local.domain_name}/*"
       }
     ]

--- a/modules/opensearch/main.tf
+++ b/modules/opensearch/main.tf
@@ -1,0 +1,118 @@
+locals {
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+
+  domain_name = "${var.project_name}-${var.environment}"
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ------------------------------------------------------------------------------
+# CloudWatch Log Group for OpenSearch
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "opensearch" {
+  name              = "/aws/opensearch/${local.domain_name}/index-slow-logs"
+  retention_in_days = var.log_retention_days
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-opensearch-logs"
+  })
+}
+
+resource "aws_cloudwatch_log_resource_policy" "opensearch" {
+  policy_name = "${local.domain_name}-opensearch-log-policy"
+
+  policy_document = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "es.amazonaws.com"
+        }
+        Action = [
+          "logs:PutLogEvents",
+          "logs:PutLogEventsBatch",
+          "logs:CreateLogStream",
+        ]
+        Resource = "${aws_cloudwatch_log_group.opensearch.arn}:*"
+      }
+    ]
+  })
+}
+
+# ------------------------------------------------------------------------------
+# OpenSearch Domain
+# ------------------------------------------------------------------------------
+
+resource "aws_opensearch_domain" "main" {
+  domain_name    = local.domain_name
+  engine_version = var.engine_version
+
+  cluster_config {
+    instance_type          = var.instance_type
+    instance_count         = var.instance_count
+    zone_awareness_enabled = var.multi_az
+
+    dynamic "zone_awareness_config" {
+      for_each = var.multi_az ? [1] : []
+      content {
+        availability_zone_count = 2
+      }
+    }
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = var.ebs_volume_size
+    volume_type = var.ebs_volume_type
+  }
+
+  vpc_options {
+    subnet_ids         = var.multi_az ? slice(var.private_subnet_ids, 0, 2) : [var.private_subnet_ids[0]]
+    security_group_ids = [aws_security_group.opensearch.id]
+  }
+
+  encrypt_at_rest {
+    enabled = true
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  # Open access policy — access is controlled via VPC security group
+  access_policies = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "es:*"
+        Resource  = "arn:aws:es:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:domain/${local.domain_name}/*"
+      }
+    ]
+  })
+
+  log_publishing_options {
+    cloudwatch_log_group_arn = aws_cloudwatch_log_group.opensearch.arn
+    log_type                 = "INDEX_SLOW_LOGS"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-opensearch"
+  })
+
+  depends_on = [
+    aws_cloudwatch_log_resource_policy.opensearch,
+  ]
+}

--- a/modules/opensearch/outputs.tf
+++ b/modules/opensearch/outputs.tf
@@ -1,0 +1,19 @@
+output "domain_endpoint" {
+  description = "HTTPS endpoint of the OpenSearch domain"
+  value       = "https://${aws_opensearch_domain.main.endpoint}"
+}
+
+output "domain_arn" {
+  description = "ARN of the OpenSearch domain"
+  value       = aws_opensearch_domain.main.arn
+}
+
+output "domain_name" {
+  description = "Name of the OpenSearch domain"
+  value       = aws_opensearch_domain.main.domain_name
+}
+
+output "security_group_id" {
+  description = "ID of the OpenSearch security group"
+  value       = aws_security_group.opensearch.id
+}

--- a/modules/opensearch/security.tf
+++ b/modules/opensearch/security.tf
@@ -1,0 +1,24 @@
+# ------------------------------------------------------------------------------
+# Security Group for OpenSearch Domain
+# ------------------------------------------------------------------------------
+
+resource "aws_security_group" "opensearch" {
+  name        = "${var.project_name}-${var.environment}-opensearch-sg"
+  description = "Security group for ${var.project_name}-${var.environment} OpenSearch domain"
+  vpc_id      = var.vpc_id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-${var.environment}-opensearch-sg"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "opensearch_https" {
+  count = length(var.allowed_security_group_ids)
+
+  security_group_id            = aws_security_group.opensearch.id
+  description                  = "Allow HTTPS access from allowed security group"
+  from_port                    = 443
+  to_port                      = 443
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = var.allowed_security_group_ids[count.index]
+}

--- a/modules/opensearch/variables.tf
+++ b/modules/opensearch/variables.tf
@@ -50,6 +50,11 @@ variable "instance_count" {
   description = "Number of data nodes in the cluster"
   type        = number
   default     = 1
+
+  validation {
+    condition     = var.instance_count >= 1
+    error_message = "instance_count must be at least 1."
+  }
 }
 
 variable "ebs_volume_size" {

--- a/modules/opensearch/variables.tf
+++ b/modules/opensearch/variables.tf
@@ -1,0 +1,82 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for resource tagging"
+  type        = string
+  default     = "vibevault"
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where the OpenSearch domain will be deployed"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs for VPC endpoint placement"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.private_subnet_ids) >= 1
+    error_message = "At least 1 private subnet ID must be provided."
+  }
+}
+
+variable "allowed_security_group_ids" {
+  description = "List of security group IDs allowed to access the OpenSearch domain (e.g. EKS worker nodes)"
+  type        = list(string)
+
+  validation {
+    condition     = length(var.allowed_security_group_ids) >= 1
+    error_message = "At least 1 security group ID must be provided for OpenSearch ingress."
+  }
+}
+
+variable "engine_version" {
+  description = "OpenSearch engine version"
+  type        = string
+  default     = "OpenSearch_2.17"
+}
+
+variable "instance_type" {
+  description = "OpenSearch instance type"
+  type        = string
+  default     = "t3.small.search"
+}
+
+variable "instance_count" {
+  description = "Number of data nodes in the cluster"
+  type        = number
+  default     = 1
+}
+
+variable "ebs_volume_size" {
+  description = "Size of EBS volume per data node in GB"
+  type        = number
+  default     = 10
+}
+
+variable "ebs_volume_type" {
+  description = "EBS volume type"
+  type        = string
+  default     = "gp3"
+}
+
+variable "multi_az" {
+  description = "Whether to enable multi-AZ deployment (requires even instance_count)"
+  type        = bool
+  default     = false
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain OpenSearch CloudWatch logs"
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.log_retention_days)
+    error_message = "log_retention_days must be a valid CloudWatch Logs retention value."
+  }
+}


### PR DESCRIPTION
## Summary
- Create `modules/opensearch/` Terraform module for AWS OpenSearch Service
- VPC-based deployment in private subnets with security group restricted to EKS workers
- Encryption at rest, node-to-node encryption, TLS 1.2 enforced, no public access
- Wire into dev environment with single-node `t3.small.search` (capstone cost optimization)

## Module structure
```
modules/opensearch/
├── main.tf          # OpenSearch domain, CloudWatch logs, access policy
├── security.tf      # Security group (HTTPS from EKS only)
├── variables.tf     # Instance type, EBS, engine version, multi-AZ, etc.
└── outputs.tf       # Domain endpoint, ARN, name, SG ID
```

## Dev configuration
- Engine: OpenSearch 2.17 (Elasticsearch client compatible)
- Instance: `t3.small.search` × 1
- EBS: 10 GB gp3
- Network: VPC private subnet, HTTPS only

## Test plan
- [x] `terraform validate` passes
- [ ] `terraform plan` shows expected resources
- [ ] `terraform apply` creates OpenSearch domain
- [ ] Productservice on EKS can connect to OpenSearch endpoint

## Related
- productservice ES integration: spa-raj/productservice#59

Fixes #20