### PR TITLE
Skip EKS access entry creation when it exists outside Terraform

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -33,6 +33,7 @@ module "eks" {
   endpoint_public_access_cidrs     = ["0.0.0.0/0"]
   control_plane_log_retention_days = 7
   ci_cd_role_arn                   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/vibevault-github-actions"
+  create_ci_cd_access_entry        = false  # Access entry already exists outside Terraform
 
   secret_arns          = concat(module.secrets.all_secret_arns, [module.rds.master_user_secret_arn])
   secrets_kms_key_arns = [module.rds.kms_key_arn]

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -129,7 +129,7 @@ resource "aws_eks_node_group" "main" {
 # ------------------------------------------------------------------------------
 
 resource "aws_eks_access_entry" "ci_cd" {
-  count         = var.ci_cd_role_arn != "" ? 1 : 0
+  count         = var.ci_cd_role_arn != "" && var.create_ci_cd_access_entry ? 1 : 0
   cluster_name  = aws_eks_cluster.main.name
   principal_arn = var.ci_cd_role_arn
   type          = "STANDARD"
@@ -137,10 +137,11 @@ resource "aws_eks_access_entry" "ci_cd" {
   tags = merge(local.common_tags, {
     Name = "${var.project_name}-${var.environment}-cicd-access"
   })
+
 }
 
 resource "aws_eks_access_policy_association" "ci_cd_admin" {
-  count         = var.ci_cd_role_arn != "" ? 1 : 0
+  count         = var.ci_cd_role_arn != "" && var.create_ci_cd_access_entry ? 1 : 0
   cluster_name  = aws_eks_cluster.main.name
   principal_arn = var.ci_cd_role_arn
   policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -104,6 +104,12 @@ variable "ci_cd_role_arn" {
   default     = ""
 }
 
+variable "create_ci_cd_access_entry" {
+  description = "Whether to create the EKS access entry for CI/CD role. Set to false if it already exists outside Terraform."
+  type        = bool
+  default     = true
+}
+
 variable "control_plane_log_retention_days" {
   description = "Number of days to retain EKS control plane logs in CloudWatch"
   type        = number


### PR DESCRIPTION
## Summary
- Add `create_ci_cd_access_entry` variable to EKS module (default `true`)
- Gate `aws_eks_access_entry` and `aws_eks_access_policy_association` on the new variable
- Set to `false` in dev environment where the entry already exists outside Terraform

## Problem
`terraform apply` fails with 409 `ResourceInUseException` because the CI/CD access entry was created outside Terraform and cannot be imported due to a provider bug with IAM ARN parsing.

## Test plan
- [ ] `terraform plan` shows no changes for access entry resources
- [ ] `terraform apply` succeeds without 409 error
- [ ] GitHub Actions deploy workflow still works (existing access entry untouched)

Fixes #22