### PR TITLE
Add in-cluster Kafka deployment (KRaft single-node)

### DIFF
--- a/.github/workflows/infra.yaml
+++ b/.github/workflows/infra.yaml
@@ -183,3 +183,10 @@ jobs:
           # Wait for job completion
           kubectl wait job/db-init -n vibevault --for=condition=complete --timeout=120s
           echo "DB init job completed successfully"
+
+      - name: Deploy Kafka (KRaft single-node)
+        run: |
+          kubectl apply -f k8s/kafka.yaml
+          echo "Waiting for Kafka to be ready..."
+          kubectl rollout status deployment/kafka -n vibevault --timeout=120s
+          echo "Kafka deployed successfully"

--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: vibevault
+  labels:
+    app: kafka
+    part-of: vibevault
+spec:
+  type: ClusterIP
+  selector:
+    app: kafka
+  ports:
+    - name: broker
+      port: 9092
+      targetPort: 9092
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  namespace: vibevault
+  labels:
+    app: kafka
+    part-of: vibevault
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+        part-of: vibevault
+    spec:
+      containers:
+        - name: kafka
+          image: confluentinc/cp-kafka:7.8.7
+          ports:
+            - containerPort: 9092
+            - containerPort: 9093
+          env:
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@localhost:9093"
+            - name: KAFKA_LISTENERS
+              value: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://kafka:9092"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "PLAINTEXT"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"
+            - name: CLUSTER_ID
+              value: "MkU3OEVBNTcwNTJENDM2Qk"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          readinessProbe:
+            exec:
+              command:
+                - kafka-topics
+                - --bootstrap-server
+                - localhost:9092
+                - --list
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 5
+          livenessProbe:
+            exec:
+              command:
+                - kafka-topics
+                - --bootstrap-server
+                - localhost:9092
+                - --list
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3

--- a/k8s/kafka.yaml
+++ b/k8s/kafka.yaml
@@ -27,6 +27,8 @@ metadata:
     part-of: vibevault
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: kafka
@@ -52,7 +54,7 @@ spec:
             - name: KAFKA_LISTENERS
               value: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
             - name: KAFKA_ADVERTISED_LISTENERS
-              value: "PLAINTEXT://kafka:9092"
+              value: "PLAINTEXT://kafka.vibevault.svc.cluster.local:9092"
             - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
               value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
             - name: KAFKA_CONTROLLER_LISTENER_NAMES


### PR DESCRIPTION
## Summary
- Add `k8s/kafka.yaml` — single-node Kafka broker in KRaft mode (no Zookeeper)
- Add Kafka deploy step to post-apply job in infra workflow

## Kafka Config
| Setting | Value |
|---------|-------|
| Image | confluentinc/cp-kafka:7.8.7 |
| Mode | KRaft (combined broker + controller) |
| Service | ClusterIP at kafka:9092 |
| Replicas | 1 |
| Resources | 250m-500m CPU, 512Mi-1Gi memory |
| Topics | Auto-create enabled |

## Why not MSK
- MSK minimum cost ~$150/month
- Single-node in-cluster Kafka is sufficient for capstone
- Zero extra AWS cost — runs on existing EKS nodes
- Production would use MSK for durability and multi-AZ

## Test plan
- [ ] `terraform apply` → post-apply deploys Kafka
- [ ] `kubectl get pods -n vibevault -l app=kafka` shows Running
- [ ] Cart service connects to `kafka:9092` and produces events

Fixes #24